### PR TITLE
Gdal to xarray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 .vscode/
 
+py-notebooks/
+
 *.code-workspace
 
 # Byte-compiled / optimized / DLL files

--- a/gradeit/elevation.py
+++ b/gradeit/elevation.py
@@ -18,11 +18,6 @@ import scipy as sp
 from scipy import signal
 import warnings
 
-try:
-    from osgeo import gdal
-except ImportError:
-    import gdal
-
 import xarray as xr
 
 warnings.simplefilter('ignore')
@@ -190,8 +185,6 @@ def get_raster_metadata_and_data(raster_path):
     	(Origin, yOrigin, pixelWidth, pixelHeight, bands, rows, cols, data)
     """
     data = xr.open_rasterio(raster_path)
-
-    # otherwise, GDAL successfully opened the raster file, return the data
 
     geotransform = data.transform
     xOrigin = geotransform[2]

--- a/gradeit/gradeit.py
+++ b/gradeit/gradeit.py
@@ -8,7 +8,7 @@ import numpy as np
 # TODO: Add path to raster DB as an optional argument
 def gradeit(df=None, lat_col='lat', lon_col='lon', filtering=False, source='usgs-api',
             usgs_db_path='/backup/mbap_shared/NED_13/', des_sg = 17):
-
+    
     coordinates = list(zip(df[lat_col], df[lon_col]))
 
     # Run the appropriate elevation function based on user's desired data source

--- a/setup.py
+++ b/setup.py
@@ -20,18 +20,13 @@ setuptools.setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering"
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=[
-        "gdal>=2.3",
-        "geos",
-        "ipykernel",
-        "ipython",
-        "matplotlib",
+        "xarray",
         "numpy",
         "pandas",
         "requests",
+        "rasterio",
         "scipy",
-        "sqlalchemy",
-        "psycopg2",
     ],
 )


### PR DESCRIPTION
Converts all usage of gdal to the python[ xarray package](https://docs.xarray.dev/en/stable/index.html).

My rationale for doing this is that xarray is much easier to install than gdal and it's more modern, integrating with dask which could allow us to scale this more readily in the future. 

I've tested both versions over the san francisco test trip and got identical elevation results:

## gdal version
![image](https://user-images.githubusercontent.com/1743744/167956665-f4c3d587-5d32-4b0a-9dcc-601da0607f58.png)

## xarray version
![image](https://user-images.githubusercontent.com/1743744/167956727-48a79c26-218c-403d-81ea-3b9df595de69.png)
