### PR TITLE
Ndr/update rasterio

### DIFF
--- a/gradeit/elevation.py
+++ b/gradeit/elevation.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import requests
-import rasterio 
+import rasterio
 from scipy import signal
 
 from gradeit.grade import get_distances

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gradeit",
-    version="0.1.1",
+    version="0.1.2",
     author="National Renewable Energy Laboratory",
     author_email="Jacob.Holden@nrel.gov",
     description="Road Grade Inference Tool (GradeIT) appends elevation and road grade to a sequence of GPS points.",
@@ -22,11 +22,10 @@ setuptools.setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        "xarray",
         "numpy",
         "pandas",
         "requests",
-        "rasterio<1.3",
+        "rasterio",
         "scipy",
         "tqdm",
     ],


### PR DESCRIPTION
Previously we had pinned rasterio to < 1.2 since there were issues with reading .adf files. This would update to using the latest version of rasterio (which should hopefully fix our install issues) but would also require us to update to using `.tif` files for our USGS raster data format. I've put together a script [here](https://github.com/NREL/gradeit/blob/main/scripts/get_usgs_tiles.py) for downloading the TIFF raster data from USGS. 

@jakeholden two questions:
 - are you okay if we update our eagle database to use the TIFF format?
 - does this branch resolve your GDAL install issues?